### PR TITLE
Bump Lambda Runtime : nodejs14.x to nodejs18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This generate aws resources that notify newrelic dashboard snapshot to slack.
 
 ## Pre-Requisite
 
-- Node = 14.x
+- Node = 18.x
 
 ## Setup envs
 

--- a/base.yaml
+++ b/base.yaml
@@ -70,7 +70,7 @@ Resources:
       Code:
         ZipFile: !Sub |
           #LambdaCode
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       MemorySize: 128
       Timeout: 60
       Environment:


### PR DESCRIPTION
The version of Node.js used in Runtime of Lambda was updated due to its close EOL.
https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/lambda-runtimes.html